### PR TITLE
Edit README to add chrome extension example and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ A collection of [🤗 Transformers.js](https://huggingface.co/docs/transformers.
 | [Node.js (CJS)](./node-cjs/)                            | Sentiment analysis in Node.js w/ CommonJS                   | n/a                                                                             |
 | [Next.js](./next-server/)                               | Sentiment analysis in Next.js                               | [Demo](https://huggingface.co/spaces/webml-community/next-server-template)      |
 | [SvelteKit](./sveltekit/)                               | Sentiment analysis in SvelteKit                             | [Demo](https://huggingface.co/spaces/webml-community/sveltekit-server-template) |
+| [Chrome Extension with Plasmo](https://github.com/tantara/transformers.js-chrome) | Chrome extension with Plasmo      | [Demo](https://chromewebstore.google.com/detail/private-ai-assistant-runn/jojlpeliekadmokfnikappfadbjiaghp) |
 
 Check out the Transformers.js [template](https://huggingface.co/new-space?template=static-templates%2Ftransformers.js) on Hugging Face to get started in one click!


### PR DESCRIPTION
I submitted PR https://github.com/huggingface/transformers.js-examples/pull/16 to share my chrome extension examples with Hugging Face community. I also uploaded the [chrome extension](https://chromewebstore.google.com/detail/private-ai-assistant-runn/jojlpeliekadmokfnikappfadbjiaghp) to Chrome Web Store so it would be great to add the live demo to README although my PR is pending for now. I think we can replace the link to codebase with a local directory once my PR is merged.