### PR TITLE
Add webnn-gpu and webnn-npu support for MODNet

### DIFF
--- a/video-background-removal/index.html
+++ b/video-background-removal/index.html
@@ -58,6 +58,9 @@
       </div>
     </div>
     <label id="status"></label>
+    <div>
+      <a href="?device=webgpu">WebGPU</a> · <a href="?device=webnn-gpu">WebNN GPU</a> · <a href="?device=webnn-npu">WebNN NPU</a>
+    </div>
 
     <script type="module" src="/main.js"></script>
   </body>

--- a/video-background-removal/package-lock.json
+++ b/video-background-removal/package-lock.json
@@ -8,7 +8,7 @@
       "name": "video-background-removal",
       "version": "0.0.0",
       "dependencies": {
-        "@huggingface/transformers": "^3.2.2"
+        "@huggingface/transformers": "^3.4.1"
       },
       "devDependencies": {
         "vite": "^6.0.5"
@@ -424,21 +424,21 @@
       }
     },
     "node_modules/@huggingface/jinja": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.3.2.tgz",
-      "integrity": "sha512-F2FvuIc+w1blGsaqJI/OErRbWH6bVJDCBI8Rm5D86yZ2wlwrGERsfIaru7XUv9eYC3DMP3ixDRRtF0h6d8AZcQ==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.3.3.tgz",
+      "integrity": "sha512-vQQr2JyWvVFba3Lj9es4q9vCl1sAc74fdgnEMoX8qHrXtswap9ge9uO3ONDzQB0cQ0PUyaKY2N6HaVbTBvSXvw==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@huggingface/transformers": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.2.2.tgz",
-      "integrity": "sha512-b5I1NTFtjy6bNSrlbvZaMiMfl1RE1n9Vr8ZOYonC+xDY0Nuw7hsdxHRq2FTsAiw0jhDcX5A58ru8VlfqCY8n5w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.4.1.tgz",
+      "integrity": "sha512-Inbvq9i/33kmd5XHom9MQU7NAOV5UcGmHBwBk9NFw4IPhdoTnfP7wFJxJmceYhRdS+EL1Hpw4he/Ceimau6ORg==",
       "dependencies": {
-        "@huggingface/jinja": "^0.3.2",
+        "@huggingface/jinja": "^0.3.3",
         "onnxruntime-node": "1.20.1",
-        "onnxruntime-web": "1.21.0-dev.20241205-d27fecd3d3",
+        "onnxruntime-web": "1.22.0-dev.20250306-ccf8fdd9ea",
         "sharp": "^0.33.5"
       }
     },
@@ -1287,9 +1287,9 @@
       }
     },
     "node_modules/flatbuffers": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
-      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ=="
+      "version": "25.2.10",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.2.10.tgz",
+      "integrity": "sha512-7JlN9ZvLDG1McO3kbX0k4v+SUAg48L1rIwEvN6ZQl/eCtgJz9UylTMzE9wrmYrcorgxm3CX/3T/w5VAub99UUw=="
     },
     "node_modules/foreground-child": {
       "version": "3.3.0",
@@ -1377,9 +1377,9 @@
       }
     },
     "node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
+      "integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng=="
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -1473,22 +1473,22 @@
       }
     },
     "node_modules/onnxruntime-web": {
-      "version": "1.21.0-dev.20241205-d27fecd3d3",
-      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.21.0-dev.20241205-d27fecd3d3.tgz",
-      "integrity": "sha512-neeC9mv1sFWjUFrTaDl7enufNxbtSSTwR5V2i35ga4yXWS6r1MbpUwWwD1X+VKANujbSG8M5pk/ohRAOm2QhMQ==",
+      "version": "1.22.0-dev.20250306-ccf8fdd9ea",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250306-ccf8fdd9ea.tgz",
+      "integrity": "sha512-YwqS9Qqx2eKFXIx+HQloqRUG5/STHPUuNk8wn+qVVmwXBIfNdXX0/Lm7wgo5CnC2k+yqZmjDV5V1dZi4PeSPGQ==",
       "dependencies": {
-        "flatbuffers": "^1.12.0",
+        "flatbuffers": "^25.1.24",
         "guid-typescript": "^1.0.9",
         "long": "^5.2.3",
-        "onnxruntime-common": "1.21.0-dev.20241205-6ed77cc374",
+        "onnxruntime-common": "1.22.0-dev.20250306-aafa8d170a",
         "platform": "^1.3.6",
         "protobufjs": "^7.2.4"
       }
     },
     "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
-      "version": "1.21.0-dev.20241205-6ed77cc374",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0-dev.20241205-6ed77cc374.tgz",
-      "integrity": "sha512-U4DGq/dZiboIEK0Zv1KUuWJesJ/txUALpWSXwI8kqOCSxe8GrI65xfRFeMbqYFhPVGAWZPsBpT1zo1s4ksrlrg=="
+      "version": "1.22.0-dev.20250306-aafa8d170a",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250306-aafa8d170a.tgz",
+      "integrity": "sha512-NfIQnW4lIk/8LnhnYqknYPeet0U0+AADgKQRlKex36QrNoVSCY+aNaX6wyy2VzQ4CNWxsYh0E203ajRD/zxn0g=="
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",

--- a/video-background-removal/package.json
+++ b/video-background-removal/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vite build",
     "preview": "vite preview"
   },
@@ -12,6 +12,6 @@
     "vite": "^6.0.5"
   },
   "dependencies": {
-    "@huggingface/transformers": "^3.2.2"
+    "@huggingface/transformers": "^3.4.1"
   }
 }


### PR DESCRIPTION
Add webnn-gpu and webnn-npu support for MODNet with following update:

1. Update @huggingface/transformers to 3.4.1 which includes onnxruntime-web [1.22.0-dev.20250306-ccf8fdd9ea](https://www.npmjs.com/package/onnxruntime-web/v/1.22.0-dev.20250306-ccf8fdd9ea). This ORT Web version includes the fix of [allow ops to handle ignoring an empty tensor as input](https://github.com/microsoft/onnxruntime/pull/22972) which can handle roi inputs with 0 dim for Resize nodes.
    - In [version 11](https://onnx.ai/onnx/operators/onnx__Resize.html#id16), the 1-D roi was required, starting from [v13](https://onnx.ai/onnx/operators/onnx__Resize.html#id10), the roi became optional.
    - Some ONNX conversion tools emitted an empty roi tensor when they should have ellided it completely
2. Keep the WebGPU code path
3. Add webnn-gpu and webnn-npu links and use fp16 MODNet
4. Add freeDimensionOverrides for WebNN path only
5. After setting freeDimensionOverrides, disable sizeSlider for WebNN path
6. Please note that the WebNN NPU for MODNet will work for next generation WebNN in Chromium based browsers, not for now.

@xenova PTAL

CC @huningxin @Honry