### PR TITLE
fix(models): use runtime device detection instead of hardcoded webgpu

### DIFF
--- a/next-vercel-ai-sdk/src/app/models.ts
+++ b/next-vercel-ai-sdk/src/app/models.ts
@@ -10,7 +10,6 @@ export const MODELS: ModelConfig[] = [
   {
     id: "HuggingFaceTB/SmolLM2-360M-Instruct",
     name: "SmolLM2 360M",
-    device: "webgpu",
     dtype: "q4",
     supportsWorker: true,
   },
@@ -23,26 +22,22 @@ export const MODELS: ModelConfig[] = [
   {
     id: "onnx-community/Qwen3-0.6B-ONNX",
     name: "Qwen3 0.6B",
-    device: "webgpu",
     dtype: "q4f16",
     supportsWorker: true,
   },
   {
     id: "onnx-community/Llama-3.2-1B-Instruct-q4f16",
     name: "Llama 3.2 1B",
-    device: "webgpu",
     supportsWorker: true,
   },
   {
     id: "onnx-community/DeepSeek-R1-Distill-Qwen-1.5B-ONNX",
     name: "Deepseek R1 Distill 1.5B",
-    device: "webgpu",
     dtype: "q4f16",
   },
   {
     id: "HuggingFaceTB/SmolVLM-256M-Instruct",
     name: "SmolVLM 256M (Vision)",
-    device: "webgpu",
     dtype: "fp32",
     isVisionModel: true,
     supportsWorker: true,


### PR DESCRIPTION
### Abstract
Removes hardcoded device: "webgpu" from model configs to let transformers.js automatically choose the optimal device at runtime. This avoids hard-failure on non-WebGPU environments, where gpu is explicitly set for running inference.

This maintains optimal performance on supported devices while ensuring the example works everywhere.

### Before
Hard failure on non-WebGPU environments with "Unsupported device: webgpu

### After
Auto-selects WebGPU when available, gracefully falls back to WASM
